### PR TITLE
Removed unintended validators from UpdateCourse

### DIFF
--- a/src/routes/courses.ts
+++ b/src/routes/courses.ts
@@ -141,8 +141,6 @@ export const updateCourse = [
     optional: true,
   }),
   atLeastOneBodyValueValidator(courseFields),
-  courseTitleDoesNotExistValidator,
-  courseIdDoesNotExistValidator,
   xssSanitizerMany(courseFields),
   validationCheck,
   genericSanitizerMany(courseFields),


### PR DESCRIPTION
The removed validators check if the given Title and Id already exist in the database and reject the request if they do. This is probably unintended.